### PR TITLE
fix & feat

### DIFF
--- a/nonebot/adapters/telegram/adapter.py
+++ b/nonebot/adapters/telegram/adapter.py
@@ -1,6 +1,6 @@
 import json
 import asyncio
-from typing import Any, Dict, List, cast, Optional, Tuple, Union
+from typing import Any, Dict, List, Tuple, Union, Optional, cast
 
 import anyio
 from pydantic.main import BaseModel

--- a/nonebot/adapters/telegram/adapter.py
+++ b/nonebot/adapters/telegram/adapter.py
@@ -15,11 +15,7 @@ from .bot import Bot
 from .event import Event
 from .model import InputMedia
 from .config import AdapterConfig
-from .exception import (
-    ActionFailed,
-    NetworkError,
-    ApiNotAvailable,
-)
+from .exception import ActionFailed, NetworkError, ApiNotAvailable
 
 
 def _escape_none(data: Dict[str, Any]) -> Dict[str, Any]:

--- a/nonebot/adapters/telegram/api.py
+++ b/nonebot/adapters/telegram/api.py
@@ -69,7 +69,8 @@ class API:
         ...
 
     async def delete_webhook(
-        self, drop_pending_updates: Optional[bool] = None
+        self,
+        drop_pending_updates: Optional[bool] = None,
     ) -> Literal[True]:
         ...
 
@@ -478,7 +479,10 @@ class API:
         ...
 
     async def get_user_profile_photos(
-        self, user_id: int, offset: Optional[int] = None, limit: Optional[int] = None
+        self,
+        user_id: int,
+        offset: Optional[int] = None,
+        limit: Optional[int] = None,
     ) -> UserProfilePhotos:
         ...
 
@@ -532,17 +536,24 @@ class API:
         ...
 
     async def set_chat_administrator_custom_title(
-        self, chat_id: Union[int, str], user_id: int, custom_title: str
+        self,
+        chat_id: Union[int, str],
+        user_id: int,
+        custom_title: str,
     ) -> Literal[True]:
         ...
 
     async def ban_chat_sender_chat(
-        self, chat_id: Union[int, str], sender_chat_id: int
+        self,
+        chat_id: Union[int, str],
+        sender_chat_id: int,
     ) -> Literal[True]:
         ...
 
     async def unban_chat_sender_chat(
-        self, chat_id: Union[int, str], sender_chat_id: int
+        self,
+        chat_id: Union[int, str],
+        sender_chat_id: int,
     ) -> Literal[True]:
         ...
 
@@ -579,22 +590,30 @@ class API:
         ...
 
     async def revoke_chat_invite_link(
-        self, chat_id: Union[int, str], invite_link: str
+        self,
+        chat_id: Union[int, str],
+        invite_link: str,
     ) -> ChatInviteLink:
         ...
 
     async def approve_chat_join_request(
-        self, chat_id: Union[int, str], user_id: int
+        self,
+        chat_id: Union[int, str],
+        user_id: int,
     ) -> Literal[True]:
         ...
 
     async def decline_chat_join_request(
-        self, chat_id: Union[int, str], user_id: int
+        self,
+        chat_id: Union[int, str],
+        user_id: int,
     ) -> Literal[True]:
         ...
 
     async def set_chat_photo(
-        self, chat_id: Union[int, str], photo: InputFile
+        self,
+        chat_id: Union[int, str],
+        photo: InputFile,
     ) -> Literal[True]:
         ...
 
@@ -602,12 +621,16 @@ class API:
         ...
 
     async def set_chat_title(
-        self, chat_id: Union[int, str], title: str
+        self,
+        chat_id: Union[int, str],
+        title: str,
     ) -> Literal[True]:
         ...
 
     async def set_chat_description(
-        self, chat_id: Union[int, str], description: Optional[str] = None
+        self,
+        chat_id: Union[int, str],
+        description: Optional[str] = None,
     ) -> Literal[True]:
         ...
 
@@ -620,7 +643,9 @@ class API:
         ...
 
     async def unpin_chat_message(
-        self, chat_id: Union[int, str], message_id: Optional[int] = None
+        self,
+        chat_id: Union[int, str],
+        message_id: Optional[int] = None,
     ) -> Literal[True]:
         ...
 
@@ -634,7 +659,8 @@ class API:
         ...
 
     async def get_chat_administrators(
-        self, chat_id: Union[int, str]
+        self,
+        chat_id: Union[int, str],
     ) -> List[ChatMember]:
         ...
 
@@ -642,12 +668,16 @@ class API:
         ...
 
     async def get_chat_member(
-        self, chat_id: Union[int, str], user_id: int
+        self,
+        chat_id: Union[int, str],
+        user_id: int,
     ) -> ChatMember:
         ...
 
     async def set_chat_sticker_set(
-        self, chat_id: Union[int, str], sticker_set_name: str
+        self,
+        chat_id: Union[int, str],
+        sticker_set_name: str,
     ) -> Literal[True]:
         ...
 
@@ -676,37 +706,49 @@ class API:
         ...
 
     async def close_forum_topic(
-        self, chat_id: Union[int, str], message_thread_id: int
+        self,
+        chat_id: Union[int, str],
+        message_thread_id: int,
     ) -> Literal[True]:
         ...
 
     async def reopen_forum_topic(
-        self, chat_id: Union[int, str], message_thread_id: int
+        self,
+        chat_id: Union[int, str],
+        message_thread_id: int,
     ) -> Literal[True]:
         ...
 
     async def delete_forum_topic(
-        self, chat_id: Union[int, str], message_thread_id: int
+        self,
+        chat_id: Union[int, str],
+        message_thread_id: int,
     ) -> Literal[True]:
         ...
 
     async def unpin_all_forum_topic_messages(
-        self, chat_id: Union[int, str], message_thread_id: int
+        self,
+        chat_id: Union[int, str],
+        message_thread_id: int,
     ) -> Literal[True]:
         ...
 
     async def edit_general_forum_topic(
-        self, chat_id: Union[int, str], name: str
+        self,
+        chat_id: Union[int, str],
+        name: str,
     ) -> Literal[True]:
         ...
 
     async def close_general_forum_topic(
-        self, chat_id: Union[int, str]
+        self,
+        chat_id: Union[int, str],
     ) -> Literal[True]:
         ...
 
     async def reopen_general_forum_topic(
-        self, chat_id: Union[int, str]
+        self,
+        chat_id: Union[int, str],
     ) -> Literal[True]:
         ...
 
@@ -714,7 +756,8 @@ class API:
         ...
 
     async def unhide_general_forum_topic(
-        self, chat_id: Union[int, str]
+        self,
+        chat_id: Union[int, str],
     ) -> Literal[True]:
         ...
 
@@ -751,7 +794,9 @@ class API:
         ...
 
     async def set_my_name(
-        self, name: Optional[str] = None, language_code: Optional[str] = None
+        self,
+        name: Optional[str] = None,
+        language_code: Optional[str] = None,
     ) -> Literal[True]:
         ...
 
@@ -759,12 +804,15 @@ class API:
         ...
 
     async def set_my_description(
-        self, description: Optional[str] = None, language_code: Optional[str] = None
+        self,
+        description: Optional[str] = None,
+        language_code: Optional[str] = None,
     ) -> Literal[True]:
         ...
 
     async def get_my_description(
-        self, language_code: Optional[str] = None
+        self,
+        language_code: Optional[str] = None,
     ) -> BotDescription:
         ...
 
@@ -776,12 +824,15 @@ class API:
         ...
 
     async def get_my_short_description(
-        self, language_code: Optional[str] = None
+        self,
+        language_code: Optional[str] = None,
     ) -> BotShortDescription:
         ...
 
     async def set_chat_menu_button(
-        self, chat_id: Optional[int] = None, menu_button: Optional[MenuButton] = None
+        self,
+        chat_id: Optional[int] = None,
+        menu_button: Optional[MenuButton] = None,
     ) -> Literal[True]:
         ...
 
@@ -796,7 +847,8 @@ class API:
         ...
 
     async def get_my_default_administrator_rights(
-        self, for_channels: Optional[bool] = None
+        self,
+        for_channels: Optional[bool] = None,
     ) -> ChatAdministratorRights:
         ...
 
@@ -876,7 +928,9 @@ class API:
         ...
 
     async def delete_message(
-        self, chat_id: Union[int, str], message_id: int
+        self,
+        chat_id: Union[int, str],
+        message_id: int,
     ) -> Literal[True]:
         ...
 
@@ -905,12 +959,16 @@ class API:
         ...
 
     async def get_custom_emoji_stickers(
-        self, custom_emoji_ids: List[str]
+        self,
+        custom_emoji_ids: List[str],
     ) -> List[Sticker]:
         ...
 
     async def upload_sticker_file(
-        self, user_id: int, sticker: InputFile, sticker_format: str
+        self,
+        user_id: int,
+        sticker: InputFile,
+        sticker_format: str,
     ) -> File:
         ...
 
@@ -935,7 +993,9 @@ class API:
         ...
 
     async def set_sticker_position_in_set(
-        self, sticker: str, position: int
+        self,
+        sticker: str,
+        position: int,
     ) -> Literal[True]:
         ...
 
@@ -943,17 +1003,23 @@ class API:
         ...
 
     async def set_sticker_emoji_list(
-        self, sticker: str, emoji_list: List[str]
+        self,
+        sticker: str,
+        emoji_list: List[str],
     ) -> Literal[True]:
         ...
 
     async def set_sticker_keywords(
-        self, sticker: str, keywords: Optional[List[str]] = None
+        self,
+        sticker: str,
+        keywords: Optional[List[str]] = None,
     ) -> Literal[True]:
         ...
 
     async def set_sticker_mask_position(
-        self, sticker: str, mask_position: Optional[MaskPosition] = None
+        self,
+        sticker: str,
+        mask_position: Optional[MaskPosition] = None,
     ) -> Literal[True]:
         ...
 
@@ -961,12 +1027,17 @@ class API:
         ...
 
     async def set_sticker_set_thumbnail(
-        self, name: str, user_id: int, thumbnail: Optional[Union[InputFile, str]] = None
+        self,
+        name: str,
+        user_id: int,
+        thumbnail: Optional[Union[InputFile, str]] = None,
     ) -> Literal[True]:
         ...
 
     async def set_custom_emoji_sticker_set_thumbnail(
-        self, name: str, custom_emoji_id: Optional[str] = None
+        self,
+        name: str,
+        custom_emoji_id: Optional[str] = None,
     ) -> Literal[True]:
         ...
 
@@ -985,7 +1056,9 @@ class API:
         ...
 
     async def answer_web_app_query(
-        self, web_app_query_id: str, result: InlineQueryResult
+        self,
+        web_app_query_id: str,
+        result: InlineQueryResult,
     ) -> SentWebAppMessage:
         ...
 
@@ -1057,12 +1130,17 @@ class API:
         ...
 
     async def answer_pre_checkout_query(
-        self, pre_checkout_query_id: str, ok: bool, error_message: Optional[str] = None
+        self,
+        pre_checkout_query_id: str,
+        ok: bool,
+        error_message: Optional[str] = None,
     ) -> Literal[True]:
         ...
 
     async def set_passport_data_errors(
-        self, user_id: int, errors: List[PassportElementError]
+        self,
+        user_id: int,
+        errors: List[PassportElementError],
     ) -> Literal[True]:
         ...
 

--- a/nonebot/adapters/telegram/bot.py
+++ b/nonebot/adapters/telegram/bot.py
@@ -126,152 +126,163 @@ class Bot(BaseBot, API):
                 "allow_sending_without_reply": allow_sending_without_reply,
             }
         )
-        if isinstance(event, EventWithChat):
-            message_thread_id = cast(
-                Optional[int], getattr(event, "message_thread_id", None)
+
+        if not isinstance(event, EventWithChat):
+            raise ApiNotAvailable
+
+        message_thread_id = cast(
+            Optional[int], getattr(event, "message_thread_id", None)
+        )
+
+        # 普通文本
+        if isinstance(message, str):
+            return await self.send_message(
+                chat_id=event.chat.id,
+                message_thread_id=message_thread_id,
+                text=message,
+                **kwargs,
             )
-            if isinstance(message, str):
+
+        # 单个 segment
+        if isinstance(message, MessageSegment):
+            if message.is_text():
                 return await self.send_message(
                     chat_id=event.chat.id,
                     message_thread_id=message_thread_id,
-                    text=message,
+                    text=str(message),
+                    entities=[
+                        MessageEntity(
+                            type=message.type,
+                            offset=0,
+                            length=len(message.data["text"]),
+                            url=message.data.get("url"),
+                            user=message.data.get("user"),
+                            language=message.data.get("language"),
+                        )
+                    ]
+                    if message.type != "text"
+                    else None,
                     **kwargs,
                 )
-            elif isinstance(message, MessageSegment):
-                if message.is_text():
-                    return await self.send_message(
-                        chat_id=event.chat.id,
-                        message_thread_id=message_thread_id,
-                        text=str(message),
-                        entities=[
-                            MessageEntity(
-                                type=message.type,
-                                offset=0,
-                                length=len(message.data["text"]),
-                                url=message.data.get("url"),
-                                user=message.data.get("user"),
-                                language=message.data.get("language"),
-                            )
-                        ]
-                        if message.type != "text"
-                        else None,
-                        **kwargs,
-                    )
-                elif isinstance(message, File):
-                    return await self.call_api(
-                        f"send_{message.type}",
-                        chat_id=event.chat.id,
-                        message_thread_id=message_thread_id,
-                        **{message.type: message.data["file"]},
-                        **kwargs,
-                    )
-                else:
-                    return await self.call_api(
-                        f"send_{message.type}",
-                        chat_id=event.chat.id,
-                        message_thread_id=message_thread_id,
-                        **message.data,
-                        **kwargs,
-                    )
-            else:
-                entities = Message(filter(lambda x: isinstance(x, Entity), message))
-                files = Message(
-                    filter(
-                        lambda x: isinstance(x, File)
-                        and not isinstance(message, UnCombinFile),
-                        message,
-                    )
+
+            if isinstance(message, File):
+                return await self.call_api(
+                    f"send_{message.type}",
+                    chat_id=event.chat.id,
+                    message_thread_id=message_thread_id,
+                    **{message.type: message.data["file"]},
+                    **kwargs,
                 )
-                others = Message(
-                    filter(
-                        lambda x: not (isinstance(x, Entity) or isinstance(x, File))
-                        or isinstance(message, UnCombinFile),
-                        message,
+
+            return await self.call_api(
+                f"send_{message.type}",
+                chat_id=event.chat.id,
+                message_thread_id=message_thread_id,
+                **message.data,
+                **kwargs,
+            )
+
+        # message 处理
+        entities = Message(filter(lambda x: isinstance(x, Entity), message))
+        files = Message(
+            filter(
+                lambda x: isinstance(x, File) and not isinstance(message, UnCombinFile),
+                message,
+            )
+        )
+        others = Message(
+            filter(
+                lambda x: not (isinstance(x, Entity) or isinstance(x, File))
+                or isinstance(message, UnCombinFile),
+                message,
+            )
+        )
+
+        # 处理只能单独发送的特殊消息
+        if others:
+            if len(others) > 1 or files or entities:
+                raise ApiNotAvailable
+
+        if not files:
+            return await self.send_message(
+                chat_id=event.chat.id,
+                message_thread_id=message_thread_id,
+                text=str(message),
+                entities=[
+                    MessageEntity(
+                        type=entity.type,
+                        offset=sum(map(len, message[:i])),
+                        length=len(entity.data["text"]),
+                        url=entity.data.get("url"),
+                        user=entity.data.get("user"),
+                        language=entity.data.get("language"),
                     )
+                    for i, entity in enumerate(message)
+                    if entity.is_text() and entity.type != "text"
+                ],
+                **kwargs,
+            )
+
+        # 发送带文件的消息
+        if len(files) > 1:
+            # 多个文件
+            medias = [
+                InputMedia(
+                    type=file.type,
+                    media=file.data["file"],
                 )
-                if others:
-                    if len(others) > 1 or files or entities:
-                        raise ApiNotAvailable
-                elif files:
-                    if len(files) > 1:
-                        medias = [
-                            InputMedia(
-                                type=file.type,
-                                media=file.data["file"],
-                            )
-                            for file in files
-                        ]
+                for file in files
+            ]
 
-                        try:
-                            media_will_edit = medias[media_group_caption_index]
-                        except IndexError:
-                            media_will_edit = medias[0]
+            try:
+                media_will_edit = medias[media_group_caption_index]
+            except IndexError:
+                media_will_edit = medias[0]
 
-                        media_will_edit.caption = str(entities)
-                        media_will_edit.caption_entities = [
-                            MessageEntity(
-                                type=entity.type,
-                                offset=sum(map(len, message[:i])),
-                                length=len(entity.data["text"]),
-                                url=entity.data.get("url"),
-                                user=entity.data.get("user"),
-                                language=entity.data.get("language"),
-                            )
-                            for i, entity in enumerate(message)
-                            if entity.is_text() and entity.type != "text"
-                        ]
+            media_will_edit.caption = str(entities)
+            media_will_edit.caption_entities = [
+                MessageEntity(
+                    type=entity.type,
+                    offset=sum(map(len, message[:i])),
+                    length=len(entity.data["text"]),
+                    url=entity.data.get("url"),
+                    user=entity.data.get("user"),
+                    language=entity.data.get("language"),
+                )
+                for i, entity in enumerate(message)
+                if entity.is_text() and entity.type != "text"
+            ]
 
-                        return await self.send_media_group(
-                            chat_id=event.chat.id,
-                            message_thread_id=message_thread_id,
-                            media=medias,  # type:ignore
-                            **kwargs,
-                        )
+            return await self.send_media_group(
+                chat_id=event.chat.id,
+                message_thread_id=message_thread_id,
+                media=medias,  # type:ignore
+                **kwargs,
+            )
 
-                    else:
-                        file = files[0]
-                        return await self.call_api(
-                            f"send_{file.type}",
-                            chat_id=event.chat.id,
-                            message_thread_id=message_thread_id,
-                            **{
-                                file.type: file.data.get("file"),
-                                "caption": str(entities) if entities else None,
-                                "caption_entities": [
-                                    MessageEntity(
-                                        type=entity.type,
-                                        offset=sum(map(len, message[:i])),
-                                        length=len(entity.data["text"]),
-                                        url=entity.data.get("url"),
-                                        user=entity.data.get("user"),
-                                        language=entity.data.get("language"),
-                                    )
-                                    for i, entity in enumerate(message)
-                                    if entity.is_text() and entity.type != "text"
-                                ]
-                                if entities
-                                else None,
-                            },
-                            **kwargs,
-                        )
-                else:
-                    return await self.send_message(
-                        chat_id=event.chat.id,
-                        message_thread_id=message_thread_id,
-                        text=str(message),
-                        entities=[
-                            MessageEntity(
-                                type=entity.type,
-                                offset=sum(map(len, message[:i])),
-                                length=len(entity.data["text"]),
-                                url=entity.data.get("url"),
-                                user=entity.data.get("user"),
-                                language=entity.data.get("language"),
-                            )
-                            for i, entity in enumerate(message)
-                            if entity.is_text() and entity.type != "text"
-                        ],
-                        **kwargs,
+        # 单个文件
+        file = files[0]
+        return await self.call_api(
+            f"send_{file.type}",
+            chat_id=event.chat.id,
+            message_thread_id=message_thread_id,
+            **{
+                file.type: file.data.get("file"),
+                "caption": str(entities) if entities else None,
+                "caption_entities": [
+                    MessageEntity(
+                        type=entity.type,
+                        offset=sum(map(len, message[:i])),
+                        length=len(entity.data["text"]),
+                        url=entity.data.get("url"),
+                        user=entity.data.get("user"),
+                        language=entity.data.get("language"),
                     )
-        else:
-            raise ApiNotAvailable
+                    for i, entity in enumerate(message)
+                    if entity.is_text() and entity.type != "text"
+                ]
+                if entities
+                else None,
+            },
+            **kwargs,
+        )

--- a/nonebot/adapters/telegram/event.py
+++ b/nonebot/adapters/telegram/event.py
@@ -421,7 +421,7 @@ class NoticeEvent(Event):
 
 class PinnedMessageEvent(NoticeEvent):
     message_id: int
-    from_: User = Field(alias="from")
+    from_: Optional[User] = Field(alias="from")
     sender_chat: Optional[Chat]
     chat: Chat
     date: int

--- a/nonebot/adapters/telegram/message.py
+++ b/nonebot/adapters/telegram/message.py
@@ -38,13 +38,17 @@ class MessageSegment(BaseMessageSegment):
     @staticmethod
     def location(latitude: float, longitude: float) -> "MessageSegment":
         return MessageSegment(
-            "location", {"latitude": latitude, "longitute": longitude}
+            "location",
+            {"latitude": latitude, "longitute": longitude},
         )
 
     # TODO need test
     @staticmethod
     def venue(
-        latitude: float, longitude: float, title: str, address: str
+        latitude: float,
+        longitude: float,
+        title: str,
+        address: str,
     ) -> "MessageSegment":
         return MessageSegment("venue", {"latitude": latitude, "longitute": longitude})
 
@@ -75,7 +79,7 @@ class MessageSegment(BaseMessageSegment):
             "find_location",
             "record_video_note",
             "upload_video_note",
-        ]
+        ],
     ) -> "MessageSegment":
         """
         仅发送，用于提醒用户机器人正在准备什么
@@ -179,14 +183,16 @@ class Entity(MessageSegment):
     @staticmethod
     def custom_emoji(text: str, custom_emoji_id: str) -> "Entity":
         return Entity(
-            "custom_emoji", {"text": text, "custom_emoji_id": custom_emoji_id}
+            "custom_emoji",
+            {"text": text, "custom_emoji_id": custom_emoji_id},
         )
 
 
 class File(MessageSegment):
     @staticmethod
     def photo(
-        file: Union[str, bytes], has_spoiler: Optional[bool] = None
+        file: Union[str, bytes],
+        has_spoiler: Optional[bool] = None,
     ) -> "MessageSegment":
         return File("photo", {"file": file, "has_spoiler": has_spoiler})
 
@@ -228,7 +234,8 @@ class File(MessageSegment):
         has_spoiler: Optional[bool] = None,
     ) -> "MessageSegment":
         return File(
-            "video", {"file": file, "thumbnail": thumbnail, "has_spoiler": has_spoiler}
+            "video",
+            {"file": file, "thumbnail": thumbnail, "has_spoiler": has_spoiler},
         )
 
 
@@ -272,14 +279,14 @@ class Message(BaseMessage[MessageSegment]):
             for entity in obj.get(entities_key, ()):
                 if entity["offset"] > offset:
                     msg.append(
-                        Entity("text", {"text": obj[key][offset : entity["offset"]]})
+                        Entity("text", {"text": obj[key][offset : entity["offset"]]}),
                     )
                 nb_entity = Entity(
                     entity["type"],
                     {
                         "text": obj[key][
                             entity["offset"] : entity["offset"] + entity["length"]
-                        ]
+                        ],
                     },
                 )
                 if "language" in entity:
@@ -309,7 +316,8 @@ class Message(BaseMessage[MessageSegment]):
                 seg = UnCombinFile(key, {"file": obj[key]["file_id"]})
             elif key == "dice":
                 seg = MessageSegment(
-                    key, {"emoji": obj[key]["emoji"], "value": obj[key]["value"]}
+                    key,
+                    {"emoji": obj[key]["emoji"], "value": obj[key]["value"]},
                 )
             elif key == "poll":
                 seg = MessageSegment(

--- a/nonebot/adapters/telegram/model.py
+++ b/nonebot/adapters/telegram/model.py
@@ -786,7 +786,7 @@ InputFile = bytes
 
 class InputMedia(BaseModel):
     type: str
-    media: str
+    media: Union[str, bytes]
     caption: Optional[str] = None
     parse_mode: Optional[str] = None
     caption_entities: Optional[List[MessageEntity]] = None

--- a/nonebot/adapters/telegram/model.py
+++ b/nonebot/adapters/telegram/model.py
@@ -1,4 +1,4 @@
-from typing import List, Union, Literal, Optional
+from typing import List, Tuple, Union, Literal, Optional
 
 from pydantic import Field, BaseModel
 
@@ -786,7 +786,7 @@ InputFile = bytes
 
 class InputMedia(BaseModel):
     type: str
-    media: Union[str, bytes]
+    media: Union[str, bytes, Tuple[str, bytes]]
     caption: Optional[str] = None
     parse_mode: Optional[str] = None
     caption_entities: Optional[List[MessageEntity]] = None


### PR DESCRIPTION
- `bot.send` 方法新增 `media_group_caption_index` 参数，用于指定 `caption` 加在哪个 `InputMedia` 下，在发送文件组时可能会有用（比如设为 `-1` 将文字置底，就像下面这样）  
  ![image](https://user-images.githubusercontent.com/59048777/236725228-68b37d77-944b-45c1-b18e-b4e5c40f1d3a.png)
- 调整 `InputMedia` 的 `media` 属性的类型为 `Union[str, bytes, Tuple[str, bytes]]`，支持在该类型中指定其上传文件名
- 修复一些 bug，调整了一些小细节