### PR TITLE
`PinnedMessageEvent.from` 应为 `Optional`

### DIFF
--- a/nonebot/adapters/telegram/event.py
+++ b/nonebot/adapters/telegram/event.py
@@ -439,7 +439,7 @@ class NoticeEvent(Event):
 
 class PinnedMessageEvent(NoticeEvent):
     message_id: int
-    from_: User = Field(alias="from")
+    from_: Optional[User] = Field(alias="from")
     sender_chat: Optional[Chat]
     chat: Chat
     date: int


### PR DESCRIPTION
#28 