### PR TITLE
修复 edit_message_media缺少对media的处理的问题

### DIFF
--- a/nonebot/adapters/telegram/adapter.py
+++ b/nonebot/adapters/telegram/adapter.py
@@ -185,7 +185,7 @@ class Adapter(BaseAdapter):
                     media.media = f"attach://{filename}"
         # 对修改消息媒体消息的处理
         elif api == "editMessageMedia":
-            media:Iterable[InputMedia] = data["media"]
+            media: Iterable[InputMedia] = data["media"]
             filename = await process_input_file(media.media)
             if filename:
                 media.media = f"attach://{filename}"

--- a/nonebot/adapters/telegram/adapter.py
+++ b/nonebot/adapters/telegram/adapter.py
@@ -183,7 +183,12 @@ class Adapter(BaseAdapter):
                 filename = await process_input_file(media.media)
                 if filename:
                     media.media = f"attach://{filename}"
-
+        # 对修改消息媒体消息的处理
+        elif api == "editMessageMedia":
+            media:Iterable[InputMedia] = data["media"]
+            filename = await process_input_file(media.media)
+            if filename:
+                media.media = f"attach://{filename}"
         # 单个文件
         elif api in (
             "sendPhoto",


### PR DESCRIPTION
adapter的_call_api没有针对editMessageMedia的处理,导致edit_message_media传入的data中的media的bytes无法被替换成正确的str,导致后面 "处理 data 以符合 DataTypes" 遇到无法处理的bytes而报错