### PR TITLE
fix pydantic V2 rename

### DIFF
--- a/nonebot/adapters/telegram/config.py
+++ b/nonebot/adapters/telegram/config.py
@@ -21,10 +21,11 @@ class BotConfig(BaseModel):
 
     if PYDANTIC_V2:
         model_config: ConfigDict = ConfigDict(
-            extra = "ignore",
-            populate_by_name = True,
+            extra="ignore",
+            populate_by_name=True,
         )
     else:
+
         class Config:
             extra = "ignore"
             allow_population_by_field_name = True
@@ -47,10 +48,11 @@ class AdapterConfig(BaseModel):
 
     if PYDANTIC_V2:
         model_config: ConfigDict = ConfigDict(
-            extra = "ignore",
-            populate_by_name = True,
+            extra="ignore",
+            populate_by_name=True,
         )
     else:
+
         class Config:
             extra = "ignore"
             allow_population_by_field_name = True

--- a/nonebot/adapters/telegram/config.py
+++ b/nonebot/adapters/telegram/config.py
@@ -20,7 +20,7 @@ class BotConfig(BaseModel):
 
     class Config:
         extra = "ignore"
-        allow_population_by_field_name = True
+        populate_by_name = True
 
 
 class AdapterConfig(BaseModel):

--- a/nonebot/adapters/telegram/config.py
+++ b/nonebot/adapters/telegram/config.py
@@ -1,6 +1,7 @@
 from typing import List, Optional
 
 from pydantic import Field, BaseModel
+from nonebot.compat import PYDANTIC_V2, ConfigDict
 
 
 class BotConfig(BaseModel):
@@ -18,9 +19,15 @@ class BotConfig(BaseModel):
     api_server: str = "https://api.telegram.org/"
     is_webhook: bool = False
 
-    class Config:
-        extra = "ignore"
-        populate_by_name = True
+    if PYDANTIC_V2:
+        model_config: ConfigDict = ConfigDict(
+            extra = "ignore",
+            populate_by_name = True,
+        )
+    else:
+        class Config:
+            extra = "ignore"
+            allow_population_by_field_name = True
 
 
 class AdapterConfig(BaseModel):
@@ -38,6 +45,12 @@ class AdapterConfig(BaseModel):
     telegram_bots: List["BotConfig"] = []
     telegram_webhook_url: Optional[str] = None
 
-    class Config:
-        extra = "ignore"
-        allow_population_by_field_name = True
+    if PYDANTIC_V2:
+        model_config: ConfigDict = ConfigDict(
+            extra = "ignore",
+            populate_by_name = True,
+        )
+    else:
+        class Config:
+            extra = "ignore"
+            allow_population_by_field_name = True


### PR DESCRIPTION
![image](https://github.com/nonebot/adapter-telegram/assets/53274578/c5c04ca0-c738-4a14-8e82-9eb1a8849130)
```
UserWarning: Valid config keys have changed in V2:
* 'allow_population_by_field_name' has been renamed to 'populate_by_name'
warnings.warn(message, UserWarning)
```