### PR TITLE
:sparkles: Support bots in Telegram test server.

### DIFF
--- a/nonebot/adapters/telegram/adapter.py
+++ b/nonebot/adapters/telegram/adapter.py
@@ -227,9 +227,10 @@ class Adapter(BaseAdapter):
 
         log("DEBUG", f"Calling API <y>{api}</y>")
         log("DEBUG", f"Calling API <y>{escape_tag(str(data))}</y>")
+        test = "/test" if bot.bot_config.is_test else ""
         request = Request(
             "POST",
-            f"{bot.bot_config.api_server}bot{bot.bot_config.token}/{api}",
+            f"{bot.bot_config.api_server}bot{bot.bot_config.token}{test}/{api}",
             data=data if files else None,
             json=data if not files else None,
             files=files,  # type: ignore

--- a/nonebot/adapters/telegram/config.py
+++ b/nonebot/adapters/telegram/config.py
@@ -10,12 +10,14 @@ class BotConfig(BaseModel):
     :配置项:
       - ``token``: telegram bot token
       - ``api_server``: 自定义 API 服务器
+      - ``is_test``: 是否为 Telegram 测试服务器中的机器人
       - ``is_webhook``: 是否使用 webhook
 
     """
 
     token: str
     api_server: str = "https://api.telegram.org/"
+    is_test: bool = False
     is_webhook: bool = False
 
 


### PR DESCRIPTION
参见：<https://core.telegram.org/bots/features#creating-a-bot-in-the-test-environment>

简单来说，Telegram 除了普通用户所在的生产服务器外，还有供开发者测试用的测试服务器。要在测试服务器上使用机器人，需要使用类似于 `https://api.telegram.org/bot<token>/test/METHOD_NAME` 的 URL。